### PR TITLE
refactor: implement JWT authentication with standard Spring Security pattern

### DIFF
--- a/src/main/java/dev/gunn96/popcat/security/SecurityConfig.java
+++ b/src/main/java/dev/gunn96/popcat/security/SecurityConfig.java
@@ -1,9 +1,12 @@
 package dev.gunn96.popcat.security;
 
 import dev.gunn96.popcat.security.jwt.JwtAuthenticationFilter;
+import dev.gunn96.popcat.security.jwt.JwtAuthenticationProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
@@ -30,7 +34,13 @@ public class SecurityConfig {
                         .requestMatchers("/pops").authenticated()
                         .anyRequest().authenticated()
                 )
+                .authenticationProvider(jwtAuthenticationProvider)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
     }
 }

--- a/src/main/java/dev/gunn96/popcat/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/dev/gunn96/popcat/security/jwt/JwtAuthenticationFilter.java
@@ -1,18 +1,19 @@
 package dev.gunn96.popcat.security.jwt;
 
-import dev.gunn96.popcat.exception.JwtException;
+import dev.gunn96.popcat.util.IpAddressUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Collections;
 
 @Component
 @RequiredArgsConstructor
@@ -20,38 +21,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
 
-    private final JwtProvider jwtProvider;
-    // TODO: GeoIP 서비스 주입 필요
+    private final AuthenticationManager authenticationManager;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
-            String bearerToken = extractBearerToken(request);
-            if (bearerToken != null) {
-                String ipAddress = request.getRemoteAddr();
-                // TODO: GeoIP 서비스로 실제 region code 가져오기
-                String regionCode = "UNKNOWN";
-
-                TokenClaims claims = jwtProvider.validateToken(bearerToken, ipAddress, regionCode);
-
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(claims, null, Collections.emptyList());
-
+            String token = extractBearerTokenThatRemovedPrefix(request);
+            if (token != null) {
+                String ipAddress = IpAddressUtil.extractIpAddress(request);
+                JwtAuthenticationToken authRequest = new JwtAuthenticationToken(token, ipAddress);
+                Authentication authentication = authenticationManager.authenticate(authRequest);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
-        } catch (JwtException e) {
+        } catch (AuthenticationException e) {
             SecurityContextHolder.clearContext();
         }
 
         filterChain.doFilter(request, response);
     }
 
-    private String extractBearerToken(HttpServletRequest request) {
+    private String extractBearerTokenThatRemovedPrefix(HttpServletRequest request) {
         String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
-
         if (authorizationHeader != null && authorizationHeader.startsWith(BEARER_PREFIX)) {
             return authorizationHeader.substring(BEARER_PREFIX.length());
         }
-
         return null;
     }
 }

--- a/src/main/java/dev/gunn96/popcat/security/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/dev/gunn96/popcat/security/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,43 @@
+package dev.gunn96.popcat.security.jwt;
+
+import dev.gunn96.popcat.service.GeoIpService;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+    private final JwtProvider jwtProvider;
+    private final GeoIpService geoIpService;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        if (!supports(authentication.getClass())) {
+            throw new IllegalArgumentException("Unsupported authentication type");
+        }
+
+        JwtAuthenticationToken jwtAuthentication = (JwtAuthenticationToken) authentication;
+        String token = (String) jwtAuthentication.getCredentials();
+        String ipAddress = jwtAuthentication.getIpAddress();
+
+        try {
+            String regionCode = geoIpService.findRegionCodeByIpAddress(ipAddress);
+            TokenClaims claims = jwtProvider.validateToken(token, ipAddress, regionCode);
+            return new JwtAuthenticationToken(claims, ipAddress, Collections.emptyList());
+        } catch (JwtException e) {
+            throw new BadCredentialsException("Invalid JWT token", e);
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/dev/gunn96/popcat/security/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/dev/gunn96/popcat/security/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,43 @@
+package dev.gunn96.popcat.security.jwt;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+    private final String token;
+    private final String ipAddress;  // IP 주소 정보 추가
+    private TokenClaims claims;
+
+    // 인증 전
+    public JwtAuthenticationToken(String token, String ipAddress) {
+        super(null);
+        this.token = token;
+        this.ipAddress = ipAddress;
+        setAuthenticated(false);
+    }
+
+    // 인증 후
+    public JwtAuthenticationToken(TokenClaims claims, String ipAddress, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.token = null;
+        this.ipAddress = ipAddress;
+        this.claims = claims;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return token;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return claims;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+}

--- a/src/test/java/dev/gunn96/popcat/security/jwt/JwtAuthenticationProviderTest.java
+++ b/src/test/java/dev/gunn96/popcat/security/jwt/JwtAuthenticationProviderTest.java
@@ -1,0 +1,98 @@
+package dev.gunn96.popcat.security.jwt;
+
+import dev.gunn96.popcat.service.GeoIpService;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationProviderTest {
+
+    @Mock
+    private JwtProvider jwtProvider;
+    @Mock
+    private GeoIpService geoIpService;
+
+    private JwtAuthenticationProvider authenticationProvider;
+
+    @BeforeEach
+    void setUp() {
+        authenticationProvider = new JwtAuthenticationProvider(jwtProvider, geoIpService);
+    }
+
+    @Test
+    @DisplayName("유효한 JWT 토큰 인증 성공")
+    void authenticate_ValidToken_Success() {
+        // given
+        String token = "valid.jwt.token";
+        String ipAddress = "127.0.0.1";
+        String regionCode = "KR";
+        TokenClaims expectedClaims = TokenClaims.builder()
+                .id("id")
+                .issuer("issuer")
+                .audience(ipAddress)
+                .subject(regionCode)
+                .issuedAt(0)
+                .notBefore(0)
+                .expiresAt(0)
+                .build();
+
+        JwtAuthenticationToken authRequest = new JwtAuthenticationToken(token, ipAddress);
+
+        given(geoIpService.findRegionCodeByIpAddress(ipAddress)).willReturn(regionCode);
+        given(jwtProvider.validateToken(token, ipAddress, regionCode)).willReturn(expectedClaims);
+
+        // when
+        Authentication result = authenticationProvider.authenticate(authRequest);
+
+        // then
+        assertThat(result).isInstanceOf(JwtAuthenticationToken.class);
+        assertThat(result.isAuthenticated()).isTrue();
+        assertThat(((JwtAuthenticationToken) result).getIpAddress()).isEqualTo(ipAddress);
+        assertThat(result.getPrincipal()).isEqualTo(expectedClaims);
+    }
+
+    @Test
+    @DisplayName("잘못된 JWT 토큰으로 인증 실패")
+    void authenticate_InvalidToken_ThrowsException() {
+        // given
+        String token = "invalid.jwt.token";
+        String ipAddress = "127.0.0.1";
+        String regionCode = "KR";
+        JwtAuthenticationToken authRequest = new JwtAuthenticationToken(token, ipAddress);
+
+        given(geoIpService.findRegionCodeByIpAddress(ipAddress)).willReturn(regionCode);
+        given(jwtProvider.validateToken(token, ipAddress, regionCode))
+                .willThrow(new JwtException("Invalid token")); // 여기를 수정
+
+        // when & then
+        assertThatThrownBy(() -> authenticationProvider.authenticate(authRequest))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasCauseInstanceOf(io.jsonwebtoken.JwtException.class);  // 여기도 수정
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 Authentication 타입 검증")
+    void supports_UnsupportedType_ReturnsFalse() {
+        // when & then
+        assertThat(authenticationProvider.supports(UsernamePasswordAuthenticationToken.class)).isFalse();
+    }
+
+    @Test
+    @DisplayName("지원하는 Authentication 타입 검증")
+    void supports_SupportedType_ReturnsTrue() {
+        // when & then
+        assertThat(authenticationProvider.supports(JwtAuthenticationToken.class)).isTrue();
+    }
+}


### PR DESCRIPTION
- Apply AuthenticationProvider pattern for JWT authentication
- Add JwtAuthenticationToken to encapsulate JWT authentication info
- Modify filter to use AuthenticationManager
- Update test code to reflect changed structure