### PR TITLE
feat: add Prometheus dependency

### DIFF
--- a/alpopca-back/build.gradle
+++ b/alpopca-back/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.6.3'
     implementation 'com.maxmind.geoip2:geoip2:4.2.1'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
@@ -48,6 +49,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/alpopca-back/build.gradle
+++ b/alpopca-back/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'com.maxmind.geoip2:geoip2:4.2.1'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
@@ -49,7 +50,6 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
-    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/alpopca-back/src/main/java/dev/gunn96/popcat/config/SecurityConfig.java
+++ b/alpopca-back/src/main/java/dev/gunn96/popcat/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/").permitAll()
+                        .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/api/v1/auth/token").permitAll()
                         .requestMatchers("/api/v1/leaderboard/**").permitAll()
                         .requestMatchers("/api/v1/pop/**").authenticated()
@@ -69,7 +70,6 @@ public class SecurityConfig {
                 )
                 .authenticationProvider(jwtAuthenticationProvider)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-//                .securityMatcher("/api/v1/pop/**")
                 .build();
     }
 }

--- a/alpopca-back/src/main/resources/application.yaml
+++ b/alpopca-back/src/main/resources/application.yaml
@@ -19,6 +19,19 @@ spring:
     username: ${DB_USERNAME}
     url: ${DB_URL}
     password: ${DB_PASSWORD}
+management:
+  health:
+    redis:
+      enabled: false
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus, metrics
+  endpoint:
+    health:
+      show-details: always
+  server:
+    port: 50001
 jwt:
   secret: ${JWT_SECRET}
   server-address: 127.0.0.1


### PR DESCRIPTION
## 작업 유형
- [x] 🚀 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🔥 핫픽스

## 변경 사항
- Spring Boot Actuator 의존성 추가하여 애플리케이션 모니터링 기능 도입
- Prometheus 메트릭 수집을 위한 micrometer-registry-prometheus 의존성 추가
- /actuator/** 엔드포인트에 대한 접근 권한을 모든 사용자로 설정
- health, prometheus, metrics 엔드포인트를 50001 포트로 노출하도록 설정
- Redis health check는 비활성화하고 health 상세 정보는 항상 표시하도록 구성